### PR TITLE
Allow proceeding even if unescape fails due to unicode errors

### DIFF
--- a/plugin.video.icefilms/resources/lib/htmlcleaner.py
+++ b/plugin.video.icefilms/resources/lib/htmlcleaner.py
@@ -102,7 +102,11 @@ def replaceEntities(s):
 
 r_unescape = re.compile(r"&(#?[xX]?(?:[0-9a-fA-F]+|\w{1,8}));")
 def unescape(s):
-    return r_unescape.sub(replaceEntities, s)
+    try:
+        unescaped = r_unescape.sub(replaceEntities, s)
+    except:
+        unescaped = s
+    return unescaped
 ### End Entity Nonsense ###
 
 def cleanUnicode(string):   


### PR DESCRIPTION
XBMC can still display these strings 
- case in point, Nov 13 2014 ep of the Daily
Show, ep title was breaking the plugin but still displays correctly after the fix

(not sure if this is the ideal fix, it just worked in this specific situation but maybe the regex can fail as well in these cases)