### PR TITLE
Set default coding to UTF-8

### DIFF
--- a/plugin.video.icefilms/default.py
+++ b/plugin.video.icefilms/default.py
@@ -2484,7 +2484,7 @@ class MyPlayer (xbmc.Player):
                 
 
     def setRecentWatched(self, video):
-        if enableRecent:
+        if self.enableRecent:
             addon.log_debug('Setting recently watched: %s' % video['name'])                    
             db_connection.set_watched(self.ice_url, video_type, video['name'], video['year'], self.season, self.episode, self.imdbid)
 

--- a/plugin.video.icefilms/default.py
+++ b/plugin.video.icefilms/default.py
@@ -15,6 +15,8 @@ import threading
 import string
 import traceback
 
+reload(sys)
+sys.setdefaultencoding('utf8')
 ############ Set prepare_zip to True in order to scrape the entire site to create a new meta pack ############
 ''' 
 Setting to true will also enable a new menu option 'Create Meta Pack' which will scrape all categories and download covers & backdrops 


### PR DESCRIPTION
Handle accent in path.
Otherwise, os.path.join method fails when pathname(s) contains non-ascii chars.

In my case /home/nabil/Vid**é**os causes me problem
File "/usr/lib/python2.7/posixpath.py", line 78, in join path +=  b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 15: ordinal not in range(128)

I haven't pushed test really far, but 
```python
reload(sys)
sys.setdefaultencoding('utf8')
```
seems to do the job.