### PR TITLE
encode string to avoid KeyError: (u'\xe9',)

### DIFF
--- a/plugin.video.icefilms/default.py
+++ b/plugin.video.icefilms/default.py
@@ -2931,8 +2931,8 @@ def addDir(name, url, mode, iconimage, meta=False, imdb=False, delfromfav=False,
      ###  addDir with context menus and meta support  ###
 
      #encode url and name, so they can pass through the sys.argv[0] related strings
-     sysname = urllib.quote_plus(name)
-     sysurl = urllib.quote_plus(url)
+     sysname = urllib.quote_plus(name.encode('utf8'))
+     sysurl = urllib.quote_plus(url.encode('utf8'))
      dirmode=mode
 
      #get nice unicode name text.


### PR DESCRIPTION
was throwing an exception when listing movies
```
ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
 - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
Error Type: <type 'exceptions.KeyError'>
Error Contents: (u'\xe9',)
Traceback (most recent call last):
  File "/home/user/.kodi/addons/plugin.video.icefilms/default.py", line 3747, in <module>
    MOVIEINDEX(url)
  File "/home/user/.kodi/addons/plugin.video.icefilms/default.py", line 1418, in MOVIEINDEX
    ADD_ITEM(metaget,meta_installed,imdb_id,url,name,100, totalitems=len(temp))
  File "/home/user/.kodi/addons/plugin.video.icefilms/default.py", line 3165, in ADD_ITEM
    addDir(name,url,mode,'',meta=meta,imdb='tt'+str(imdb_id),totalItems=totalitems, meta_install=meta_installed)
  File "/home/user/.kodi/addons/plugin.video.icefilms/default.py", line 2934, in addDir
    sysname = urllib.quote_plus(name)
  File "/usr/lib/python2.7/urllib.py", line 1273, in quote_plus
    s = quote(s, safe + ' ')
  File "/usr/lib/python2.7/urllib.py", line 1268, in quote
    return ''.join(map(quoter, s))
KeyError: (u'\xe9',)
-->End of Python script error report<--
```